### PR TITLE
修复泛型识别错误

### DIFF
--- a/themes/Eva-Dark.json
+++ b/themes/Eva-Dark.json
@@ -519,7 +519,7 @@
     {
       "name": "keyword Operators increment decrement",
       "nameCN": "关键字 运算符 + - * /;自增++ 自减--;+= -=;less sass里的关键字(用于+ -号)",
-      "scope": "keyword.operator, keyword.operator.arithmetic,keyword.operator.decrement, keyword.operator.increment,keyword.operator.assignment.compound,keyword.operator.less,meta.property-list.css,keyword.operator.sass, keyword.operator.increment-decrement, keyword.operator.css, entity.name.tag.wildcard.scss, keyword.operator.string,keyword.operator.bitwise,keyword.operator.assignment.augmented,storage.type.variable.ruby, keyword.operator.assignment.arithmetic",
+      "scope": "keyword.operator, keyword.operator.arithmetic,keyword.operator.decrement, keyword.operator.increment,keyword.operator.assignment.compound,keyword.operator.less,meta.property-list.css,keyword.operator.sass, keyword.operator.increment-decrement, keyword.operator.css, entity.name.tag.wildcard.scss, keyword.operator.string,keyword.operator.assignment.augmented,storage.type.variable.ruby, keyword.operator.assignment.arithmetic",
       "settings": {
         "fontStyle": "normal",
         "foreground": "#56B7C3"
@@ -537,7 +537,7 @@
     {
       "name": "keyword Operators ternary,logical,comparison,relational,tilde",
       "nameCN": "三元运算符 ? :;logical;== === != !==;< > <= >=;正则表达式里的 或|;波浪号~",
-      "scope": "keyword.operator.ternary,keyword.operator.logical,keyword.operator.comparison,keyword.operator.relational,keyword.operator.or.regexp,keyword.operator.class,keyword.operator.type,keyword.operator.other.ruby,keyword.operator.conditional,punctuation.separator.question-mark,keyword.operator.null-coalescing,punctuation.tilde,punctuation.separator.pointer-access,punctuation.separator.namespace, keyword.operator.dart",
+      "scope": "keyword.operator.ternary,keyword.operator.logical,keyword.operator.bitwise,keyword.operator.comparison,keyword.operator.relational,keyword.operator.or.regexp,keyword.operator.class,keyword.operator.type,keyword.operator.other.ruby,keyword.operator.conditional,punctuation.separator.question-mark,keyword.operator.null-coalescing,punctuation.tilde,punctuation.separator.pointer-access,punctuation.separator.namespace, keyword.operator.dart",
       "settings": {
         "fontStyle": "normal",
         "foreground": "#CF68E1"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22249411/46121702-897df500-c247-11e8-84f1-63a109e65ab6.png)

这里死别有问题，如果这样：
![image](https://user-images.githubusercontent.com/22249411/46121717-9d295b80-c247-11e8-8bf8-a12947dde2a4.png)
正常了。但是格式化程序不允许这样，所以进行了修复。