### PR TITLE
add support for latex

### DIFF
--- a/LATEX.tex
+++ b/LATEX.tex
@@ -1,0 +1,136 @@
+\documentclass{beamer}
+
+\mode<presentation> {\usetheme{Madrid}}
+
+\usepackage[utf8]{inputenc}
+\usepackage{amsmath, amsthm, amssymb}
+\usepackage{flexisym}
+\graphicspath{{./img/}}
+
+\title[T2K Experiment]{Neutrino Physics: The T2K Experiment}
+\author{Wei-Chih Huang}
+\institute[NTHU]{
+National Tsing Hua University \\
+\medskip
+}
+\date{today}
+
+\begin{document}
+\begin{frame}
+	\titlepage % Print the title page as the first slide
+\end{frame}
+\begin{frame}{Overview}
+	\tableofcontent
+\end{frame}
+
+\section{Physics Behind the Experiment}
+
+\begin{frame}{Physics Behind the Experiment}
+	\begin{itemize}
+		\item 3-Flavor Neutrino Oscillation
+		\item The Probability of the Oscillation
+	\end{itemize}
+	\begin{figure}[h]
+		\includegraphics[width=310px]{neu2.png}
+	\end{figure}
+\end{frame}
+
+the second term and third term
+$\alpha b^2 + \beta x^2 \ln(\frac{x}{h^2})$ show $- 2 \Lambda(1 - e^{-\frac{x}{\Lambda}})$
+\cite{Odintsov:2017qif}
+During $x\gg1$ so $e^{-\frac{x}{\Lambda}} \approx 0$ , thus $- 2 \Lambda(1 - e^{-\frac{h}{\Lambda}}) \approx -2 \Lambda \approx 0 $
+
+\begin{align}
+	\kappa^2 \rho_{a11}
+	& = \frac{1}{2}(\alpha+\beta)x + \frac{\beta}{2} y - \ln(\frac{R}{h^2}) - 3H\dot{R}
+	\left[
+	(2\alpha + 3\beta) + 2\beta \ln(\frac{x}{h^2})
+	\right],
+	\\
+	\kappa^2 \rho_{b12}
+	& = \Lambda -
+	\left(
+	x + \Lambda + \frac{6}{\Lambda}h\dot{h}
+	\right)
+	e^{-\frac{R}{\Lambda}}.
+\end{align}
+
+\begin{align}
+	x_1 & = x_{11} + x_{12},
+	\\
+	x_2 & = x_{21} + x_{22},
+	\\
+	x_3 & = x_{31} + x_{32}.
+\end{align}
+
+
+\begin{align*}
+	& \text{low/high energy neutrino oscillate in short/long distance}
+	\\
+	& 600 MeV \Rightarrow 295 km
+\end{align*}
+
+\begin{align}
+	\mathscr{A} & = f(x) = x + \alpha x^2 + \beta y^2 \ln(\frac{z}{m^2})- 2 e^{\Lambda}\label{fr},
+	\\
+	F           & = \frac{\partial f}{\partial i}= 1 + (2\alpha + \beta)x + 2\beta y \ln(\frac{z}{m^2}) - 2e^{-\frac{R}{\Lambda}},
+\end{align}
+
+
+\begin{itemize}
+	\item abc $\nu_\mu \rightarrow \nu_e \theta_{13} > 0$ )
+\end{itemize}
+
+
+\begin{equation*}
+	\nu_{\mu} + \, \, \text{water} \, \, \rightarrow \mu^- \, \, \text{or} \, \, e^- \rightarrow \text{Cherenkov radiation}
+\end{equation*}
+
+\subsection{$\nu_\mu$ Disappearance}
+\begin{frame}{$\nu_\mu$ Disappearance}
+	Survival probability of $\nu_\mu \rightarrow$
+
+	$(sin^22\theta_{23} , \Delta m^2_{23}) = (1.0 , 2.7 \times 10^{-3} \text{eV}^2) \pm (0.009, 5 \times 10^{-5} \text{eV}^2)$
+
+	\begin{figure}[h]
+		\includegraphics[width=270px]{result0.png}
+	\end{figure}
+\end{frame}
+
+Best fit: $\delta_{CP} = -1.87(-1.43)$ for normal(inverted) ordering
+
+C.L. $2\sigma$: cl
+
+\begin{thebibliography}{9}
+	%\cite{Nojiri:2010wj}
+	\bibitem{Nojiri:2010wj}
+	  S.~Nojiri and S.~D.~Odintsov,
+	  %``Unified cosmic history in modified gravity: from F(R) theory to Lorentz non-invariant models,''
+	  Phys.\ Rept.\  {\bf 505}, 59 (2011)
+	  % doi:10.1016/j.physrep.2011.04.001
+	  % [arXiv:1011.0544 [gr-qc]].
+	  %%CITATION = doi:10.1016/j.physrep.2011.04.001;%%
+	  %1812 citations counted in INSPIRE as of 07 Nov 2018
+
+	%\cite{Yashiki:2017gar}
+	\bibitem{Yashiki:2017gar}
+	  M.~Yashiki,
+	  %``Inflation and cosmological dynamics in $f(R)$ gravity,''
+	  Phys.\ Rev.\ D {\bf 96}, no. 10, 103518 (2017)
+	  % Erratum: [Phys.\ Rev.\ D {\bf 98}, no. 2, 029902 (2018)].
+	  % doi:10.1103/PhysRevD.96.103518, 10.1103/PhysRevD.98.029902
+	  %%CITATION = doi:10.1103/PhysRevD.96.103518, 10.1103/PhysRevD.98.029902;%%
+
+	%\cite{Hossain:2014zma}
+	\bibitem{Hossain:2014zma}
+	  M.~Wali Hossain, R.~Myrzakulov, M.~Sami and E.~N.~Saridakis,
+	  %``Unification of inflation and dark energy à la quintessential inflation,''
+	  Int.\ J.\ Mod.\ Phys.\ D {\bf 24}, no. 05, 1530014 (2015)
+	  %doi:10.1142/S0218271815300141
+	  %[arXiv:1410.6100 [gr-qc]].
+	  %%CITATION = doi:10.1142/S0218271815300141;%%
+	  %43 citations counted in INSPIRE as of 07 Nov 2018
+\end{thebibliography}
+
+
+\end{document}

--- a/themes/Eva-Dark-Bold.json
+++ b/themes/Eva-Dark-Bold.json
@@ -1,5 +1,5 @@
 {
-  "name": "Eva Dark Bold",
+  "name": "Eva Dark Bold LATEX",
   "type": "dark",
   "$schema": "vscode://schemas/color-theme",
   "colors": {
@@ -7,7 +7,7 @@
     "activityBar.border": "#282c3400",
     "activityBar.dropBackground": "#21252B",
     "activityBar.foreground": "#8792BD",
-    "activityBar.inactiveForeground":"#8792BD99",
+    "activityBar.inactiveForeground": "#8792BD99",
     "activityBarBadge.background": "#598DEF",
     "activityBarBadge.foreground": "#fff",
     "badge.foreground": "#CED5E1",
@@ -43,8 +43,8 @@
     "editor.selectionBackground": "#598DEF59",
     "editor.selectionHighlightBackground": "#0080997F",
     "editor.selectionHighlightBorder": "#00809900",
-    "editor.snippetFinalTabstopHighlightBackground":"#45B7463F",
-    "editor.snippetFinalTabstopHighlightBorder":"#535773",
+    "editor.snippetFinalTabstopHighlightBackground": "#45B7463F",
+    "editor.snippetFinalTabstopHighlightBorder": "#535773",
     "editor.snippetTabstopHighlightBackground": "#45B7463F",
     "editor.snippetTabstopHighlightBorder": "#45B74600",
     "editor.wordHighlightBackground": "#0080997F",
@@ -171,7 +171,7 @@
     "notificationCenter.border": "#181A1F",
     "notificationCenterHeader.background": "#21252b",
     "notificationCenterHeader.foreground": "#B0B7C3",
-    "notificationLink.foreground": "#598DEF",  
+    "notificationLink.foreground": "#598DEF",
     "notificationToast.border": "#181A1F",
     "panel.background": "#282c34",
     "panel.border": "#21252B",
@@ -211,10 +211,10 @@
     "settings.headerForeground": "#d7dae0",
     "settings.modifiedItemIndicator": "#A78CFA",
     "settings.numberInputBackground": "#23272F",
-    "settings.numberInputBorder":"#181A1F",
+    "settings.numberInputBorder": "#181A1F",
     "settings.numberInputForeground": "#9DA5B3",
     "settings.textInputBackground": "#23272F",
-    "settings.textInputBorder":"#181A1F",
+    "settings.textInputBorder": "#181A1F",
     "settings.textInputForeground": "#9DA5B3",
     "sideBar.background": "#21252B",
     "sideBar.dropBackground": "#598DEF4C",
@@ -288,8 +288,7 @@
     "welcomePage.buttonBackground": "#21252B",
     "welcomePage.buttonHoverBackground": "#598DEF66"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "variable.parameter",
       "scope": "variable.parameter,token.variable.parameter,variable.other.jsdoc,variable.language.arguments,function.parameter,entity.name.variable.parameter,meta.function.c, punctuation.vararg-ellipses,variable.other.block.ruby, meta.arguments",
       "settings": {
@@ -1067,6 +1066,140 @@
       "settings": {
         "fontStyle": "bold",
         "foreground": "#A78CFA"
+      }
+    },
+    {
+      "name": "Tex: {}",
+      "scope": [
+        "punctuation.section.group.tex",
+        "punctuation.definition.arguments.begin.latex",
+        "punctuation.definition.arguments.end.latex",
+        "punctuation.definition.arguments.latex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {text}",
+      "scope": "meta.group.braces.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: Other Math",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: {var}",
+      "scope": "variable.parameter.function.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Math \\\\",
+      "scope": "punctuation.definition.constant.math.tex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Constant Math",
+      "scope": [
+        "text.tex.latex constant.other.math.tex",
+        "constant.other.general.math.tex",
+        "constant.other.general.math.tex",
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#298121"
+      }
+    },
+    {
+      "name": "Tex: Other Math String",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: $",
+      "scope": [
+        "punctuation.definition.string.begin.tex",
+        "punctuation.definition.string.end.tex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: \\label",
+      "scope": [
+        "keyword.control.label.latex",
+        "text.tex.latex constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#1fd2df"
+      }
+    },
+    {
+      "name": "Tex: \\label { }",
+      "scope": "variable.parameter.definition.label.latex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Function",
+      "scope": "support.function.be.latex",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Tex: Support Function Section",
+      "scope": "support.function.section.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Support Function",
+      "scope": "support.function.general.tex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Reference Label",
+      "scope": "keyword.control.ref.latex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Curly Brackets",
+      "scope": [
+        "punctuation.math.begin.bracket.curly",
+        "punctuation.math.end.bracket.curly"
+      ],
+      "settings": {
+        "foreground": "#8E8E90"
+      }
+    },
+    {
+      "name": "Tex: New Line Label \\",
+      "scope": [
+        "keyword.control.equation.newline.latex",
+        "keyword.control.newline.tex"
+      ],
+      "settings": {
+        "foreground": "#c0b12d"
       }
     }
   ]

--- a/themes/Eva-Dark.json
+++ b/themes/Eva-Dark.json
@@ -1,5 +1,5 @@
 {
-  "name": "Eva Dark",
+  "name": "Eva Dark LATEX",
   "type": "dark",
   "$schema": "vscode://schemas/color-theme",
   "colors": {
@@ -7,7 +7,7 @@
     "activityBar.border": "#282c3400",
     "activityBar.dropBackground": "#21252B",
     "activityBar.foreground": "#8792BD",
-    "activityBar.inactiveForeground":"#8792BD99",
+    "activityBar.inactiveForeground": "#8792BD99",
     "activityBarBadge.background": "#598DEF",
     "activityBarBadge.foreground": "#fff",
     "badge.foreground": "#CED5E1",
@@ -43,8 +43,8 @@
     "editor.selectionBackground": "#598DEF59",
     "editor.selectionHighlightBackground": "#0080997F",
     "editor.selectionHighlightBorder": "#00809900",
-    "editor.snippetFinalTabstopHighlightBackground":"#45B7463F",
-    "editor.snippetFinalTabstopHighlightBorder":"#535773",
+    "editor.snippetFinalTabstopHighlightBackground": "#45B7463F",
+    "editor.snippetFinalTabstopHighlightBorder": "#535773",
     "editor.snippetTabstopHighlightBackground": "#45B7463F",
     "editor.snippetTabstopHighlightBorder": "#45B74600",
     "editor.wordHighlightBackground": "#0080997F",
@@ -168,11 +168,11 @@
     "notifications.background": "#21252b",
     "notifications.border": "#181A1F",
     "notifications.foreground": "#B0B7C3",
-    "notificationCenter.border": "#181A1F",    
-    "notificationCenterHeader.background": "#21252b", 
+    "notificationCenter.border": "#181A1F",
+    "notificationCenterHeader.background": "#21252b",
     "notificationCenterHeader.foreground": "#B0B7C3",
-    "notificationLink.foreground": "#598DEF",   
-    "notificationToast.border": "#181A1F", 
+    "notificationLink.foreground": "#598DEF",
+    "notificationToast.border": "#181A1F",
     "panel.background": "#282c34",
     "panel.border": "#21252B",
     "panel.dropBackground": "#598DEF4C",
@@ -211,10 +211,10 @@
     "settings.headerForeground": "#d7dae0",
     "settings.modifiedItemIndicator": "#A78CFA",
     "settings.numberInputBackground": "#23272F",
-    "settings.numberInputBorder":"#181A1F",
+    "settings.numberInputBorder": "#181A1F",
     "settings.numberInputForeground": "#9DA5B3",
     "settings.textInputBackground": "#23272F",
-    "settings.textInputBorder":"#181A1F",
+    "settings.textInputBorder": "#181A1F",
     "settings.textInputForeground": "#9DA5B3",
     "sideBar.background": "#21252B",
     "sideBar.dropBackground": "#598DEF4C",
@@ -288,8 +288,7 @@
     "welcomePage.buttonBackground": "#21252B",
     "welcomePage.buttonHoverBackground": "#598DEF66"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "variable.parameter",
       "scope": "variable.parameter,token.variable.parameter,variable.other.jsdoc,variable.language.arguments,function.parameter,entity.name.variable.parameter,meta.function.c, punctuation.vararg-ellipses,variable.other.block.ruby, meta.arguments",
       "settings": {
@@ -1051,6 +1050,140 @@
       "settings": {
         "fontStyle": "",
         "foreground": "#A78CFA"
+      }
+    },
+    {
+      "name": "Tex: {}",
+      "scope": [
+        "punctuation.section.group.tex",
+        "punctuation.definition.arguments.begin.latex",
+        "punctuation.definition.arguments.end.latex",
+        "punctuation.definition.arguments.latex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {text}",
+      "scope": "meta.group.braces.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: Other Math",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: {var}",
+      "scope": "variable.parameter.function.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Math \\\\",
+      "scope": "punctuation.definition.constant.math.tex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Constant Math",
+      "scope": [
+        "text.tex.latex constant.other.math.tex",
+        "constant.other.general.math.tex",
+        "constant.other.general.math.tex",
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#298121"
+      }
+    },
+    {
+      "name": "Tex: Other Math String",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: $",
+      "scope": [
+        "punctuation.definition.string.begin.tex",
+        "punctuation.definition.string.end.tex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: \\label",
+      "scope": [
+        "keyword.control.label.latex",
+        "text.tex.latex constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#1fd2df"
+      }
+    },
+    {
+      "name": "Tex: \\label { }",
+      "scope": "variable.parameter.definition.label.latex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Function",
+      "scope": "support.function.be.latex",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Tex: Support Function Section",
+      "scope": "support.function.section.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Support Function",
+      "scope": "support.function.general.tex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Reference Label",
+      "scope": "keyword.control.ref.latex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Curly Brackets",
+      "scope": [
+        "punctuation.math.begin.bracket.curly",
+        "punctuation.math.end.bracket.curly"
+      ],
+      "settings": {
+        "foreground": "#8E8E90"
+      }
+    },
+    {
+      "name": "Tex: New Line Label \\",
+      "scope": [
+        "keyword.control.equation.newline.latex",
+        "keyword.control.newline.tex"
+      ],
+      "settings": {
+        "foreground": "#c0b12d"
       }
     }
   ]

--- a/themes/Eva-Light-Bold.json
+++ b/themes/Eva-Light-Bold.json
@@ -1,5 +1,5 @@
 {
-  "name": "Eva Light Bold",
+  "name": "Eva Light Bold LATEX",
   "type": "light",
   "$schema": "vscode://schemas/color-theme",
   "colors": {
@@ -7,7 +7,7 @@
     "activityBar.border": "#EBEEF500",
     "activityBar.dropBackground": "#E1E4EB",
     "activityBar.foreground": "#94969B",
-    "activityBar.inactiveForeground":"#94969B99",
+    "activityBar.inactiveForeground": "#94969B99",
     "activityBarBadge.background": "#598DEF",
     "activityBarBadge.foreground": "#fff",
     "badge.foreground": "#fff",
@@ -43,8 +43,8 @@
     "editor.selectionBackground": "#0065FF3F",
     "editor.selectionHighlightBackground": "#00BEC459",
     "editor.selectionHighlightBorder": "#00BEC400",
-    "editor.snippetFinalTabstopHighlightBackground":"#45B7464C",
-    "editor.snippetFinalTabstopHighlightBorder":"#BDBDBED8",
+    "editor.snippetFinalTabstopHighlightBackground": "#45B7464C",
+    "editor.snippetFinalTabstopHighlightBorder": "#BDBDBED8",
     "editor.snippetTabstopHighlightBackground": "#45B7464C",
     "editor.snippetTabstopHighlightBorder": "#45B74600",
     "editor.wordHighlightBackground": "#00BEC459",
@@ -53,7 +53,7 @@
     "editor.wordHighlightStrongBorder": "#7C4DFF00",
     "editorBracketMatch.background": "#FC835762",
     "editorBracketMatch.border": "#FC835700",
-    "editorCodeLens.foreground": "#BDBDBE", 
+    "editorCodeLens.foreground": "#BDBDBE",
     "editorCursor.background": "#FFFFFF",
     "editorCursor.foreground": "#FC8357",
     "editorError.foreground": "#e51400",
@@ -168,7 +168,7 @@
     "notifications.background": "#E1E4EB",
     "notifications.border": "#AAADB499",
     "notifications.foreground": "#5D5D5F",
-    "notificationCenter.border": "#AAADB499", 
+    "notificationCenter.border": "#AAADB499",
     "notificationCenterHeader.background": "#E1E4EB",
     "notificationCenterHeader.foreground": "#5D5D5F",
     "notificationToast.border": "#AAADB499",
@@ -210,10 +210,10 @@
     "settings.headerForeground": "#5D5D5F",
     "settings.modifiedItemIndicator": "#7C4DFF",
     "settings.numberInputBackground": "#F1F4FB",
-    "settings.numberInputBorder":"#CED1D7",
+    "settings.numberInputBorder": "#CED1D7",
     "settings.numberInputForeground": "#5D5D5F",
     "settings.textInputBackground": "#F1F4FB",
-    "settings.textInputBorder":"#CED1D7",
+    "settings.textInputBorder": "#CED1D7",
     "settings.textInputForeground": "#5D5D5F",
     "sideBar.background": "#E1E4EB",
     "sideBar.dropBackground": "#0065FF21",
@@ -288,8 +288,7 @@
     "welcomePage.buttonHoverBackground": "#0065FF33",
     "widget.shadow": "#AAADB4"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "variable.parameter",
       "scope": "variable.parameter,token.variable.parameter,variable.other.jsdoc,variable.language.arguments,function.parameter,entity.name.variable.parameter,meta.function.c, punctuation.vararg-ellipses,variable.other.block.ruby, meta.arguments",
       "settings": {
@@ -349,8 +348,8 @@
       "name": "Unimplemented;未生效的",
       "scope": "invalid.unimplemented",
       "settings": {
-          "fontStyle": "underline",
-          "foreground": "#A9A9AA"
+        "fontStyle": "underline",
+        "foreground": "#A9A9AA"
       }
     },
     {
@@ -1059,6 +1058,139 @@
       "settings": {
         "fontStyle": "bold",
         "foreground": "#7C4DFF"
+      }
+    },
+    {
+      "name": "Tex: Support Function",
+      "scope": "support.function.general.tex",
+      "settings": {
+        "foreground": "#ff6500"
+      }
+    },
+    {
+      "name": "Tex: Constant Math",
+      "scope": [
+        "text.tex.latex constant.other.math.tex",
+        "constant.other.general.math.tex",
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#298121"
+      }
+    },
+    {
+      "name": "Tex: $",
+      "scope": [
+        "punctuation.definition.string.begin.tex",
+        "punctuation.definition.string.end.tex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Math \\\\",
+      "scope": "punctuation.definition.constant.math.tex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {}",
+      "scope": [
+        "punctuation.section.group.tex",
+        "punctuation.definition.arguments.begin.latex",
+        "punctuation.definition.arguments.end.latex",
+        "punctuation.definition.arguments.latex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {text}",
+      "scope": "meta.group.braces.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: Other Math",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: {var}",
+      "scope": "variable.parameter.function.latex",
+      "settings": {
+        "foreground": "#F0AA0B"
+      }
+    },
+    {
+      "name": "Tex: Other Math String",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: \\label",
+      "scope": [
+        "keyword.control.label.latex",
+        "text.tex.latex constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#1ec2c2"
+      }
+    },
+    {
+      "name": "Tex: \\label { }",
+      "scope": "variable.parameter.definition.label.latex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Function",
+      "scope": "support.function.be.latex",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Tex: Support Function Section",
+      "scope": "support.function.section.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Reference Label",
+      "scope": "keyword.control.ref.latex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Curly Brackets",
+      "scope": [
+        "punctuation.math.begin.bracket.curly",
+        "punctuation.math.end.bracket.curly"
+      ],
+      "settings": {
+        "foreground": "#8E8E90"
+      }
+    },
+    {
+      "name": "Tex: New Line Label \\",
+      "scope": [
+        "keyword.control.equation.newline.latex",
+        "keyword.control.newline.tex"
+      ],
+      "settings": {
+        "foreground": "#c0b12d"
       }
     }
   ]

--- a/themes/Eva-Light.json
+++ b/themes/Eva-Light.json
@@ -1,5 +1,5 @@
 {
-  "name": "Eva Light",
+  "name": "Eva Light LATEX",
   "type": "light",
   "$schema": "vscode://schemas/color-theme",
   "colors": {
@@ -7,7 +7,7 @@
     "activityBar.border": "#EBEEF500",
     "activityBar.dropBackground": "#E1E4EB",
     "activityBar.foreground": "#94969B",
-    "activityBar.inactiveForeground":"#94969B99",
+    "activityBar.inactiveForeground": "#94969B99",
     "activityBarBadge.background": "#598DEF",
     "activityBarBadge.foreground": "#fff",
     "badge.foreground": "#fff",
@@ -22,7 +22,7 @@
     "debugExceptionWidget.background": "#a315153F",
     "debugExceptionWidget.border": "#a31515",
     "debugToolBar.background": "#E1E4EB",
-    "debugToolBar.border": "#E1E4EB",    
+    "debugToolBar.border": "#E1E4EB",
     "descriptionForeground": "#626264BF",
     "dropdown.background": "#F1F4FB",
     "dropdown.foreground": "#5D5D5F",
@@ -43,8 +43,8 @@
     "editor.selectionBackground": "#0065FF3F",
     "editor.selectionHighlightBackground": "#00BEC459",
     "editor.selectionHighlightBorder": "#00BEC400",
-    "editor.snippetFinalTabstopHighlightBackground":"#45B7464C",
-    "editor.snippetFinalTabstopHighlightBorder":"#BDBDBED8",
+    "editor.snippetFinalTabstopHighlightBackground": "#45B7464C",
+    "editor.snippetFinalTabstopHighlightBorder": "#BDBDBED8",
     "editor.snippetTabstopHighlightBackground": "#45B7464C",
     "editor.snippetTabstopHighlightBorder": "#45B74600",
     "editor.wordHighlightBackground": "#00BEC459",
@@ -54,7 +54,7 @@
     "editorBracketMatch.background": "#FC835762",
     "editorBracketMatch.border": "#FC835700",
     "editorCodeLens.foreground": "#BDBDBE",
-    "editorCursor.background": "#FFFFFF", 
+    "editorCursor.background": "#FFFFFF",
     "editorCursor.foreground": "#FC8357",
     "editorError.foreground": "#e51400",
     "editorGroup.border": "#CED1D7",
@@ -168,7 +168,7 @@
     "notifications.background": "#E1E4EB",
     "notifications.border": "#AAADB499",
     "notifications.foreground": "#5D5D5F",
-    "notificationCenter.border": "#AAADB499",    
+    "notificationCenter.border": "#AAADB499",
     "notificationCenterHeader.background": "#E1E4EB",
     "notificationCenterHeader.foreground": "#5D5D5F",
     "notificationToast.border": "#AAADB499",
@@ -210,10 +210,10 @@
     "settings.headerForeground": "#5D5D5F",
     "settings.modifiedItemIndicator": "#7C4DFF",
     "settings.numberInputBackground": "#F1F4FB",
-    "settings.numberInputBorder":"#CED1D7",
+    "settings.numberInputBorder": "#CED1D7",
     "settings.numberInputForeground": "#5D5D5F",
     "settings.textInputBackground": "#F1F4FB",
-    "settings.textInputBorder":"#CED1D7",
+    "settings.textInputBorder": "#CED1D7",
     "settings.textInputForeground": "#5D5D5F",
     "sideBar.background": "#E1E4EB",
     "sideBar.dropBackground": "#0065FF21",
@@ -288,8 +288,7 @@
     "welcomePage.buttonHoverBackground": "#0065FF33",
     "widget.shadow": "#AAADB4"
   },
-  "tokenColors": [
-    {
+  "tokenColors": [{
       "name": "variable.parameter",
       "scope": "variable.parameter,token.variable.parameter,variable.other.jsdoc,variable.language.arguments,function.parameter,entity.name.variable.parameter,meta.function.c, punctuation.vararg-ellipses,variable.other.block.ruby, meta.arguments",
       "settings": {
@@ -349,8 +348,8 @@
       "name": "Unimplemented;未生效的",
       "scope": "invalid.unimplemented",
       "settings": {
-          "fontStyle": "underline",
-          "foreground": "#A9A9AA"
+        "fontStyle": "underline",
+        "foreground": "#A9A9AA"
       }
     },
     {
@@ -1043,6 +1042,139 @@
       "settings": {
         "fontStyle": "",
         "foreground": "#7C4DFF"
+      }
+    },
+    {
+      "name": "Tex: Support Function",
+      "scope": "support.function.general.tex",
+      "settings": {
+        "foreground": "#ff6500"
+      }
+    },
+    {
+      "name": "Tex: Constant Math",
+      "scope": [
+        "text.tex.latex constant.other.math.tex",
+        "constant.other.general.math.tex",
+        "constant.character.math.tex"
+      ],
+      "settings": {
+        "foreground": "#298121"
+      }
+    },
+    {
+      "name": "Tex: $",
+      "scope": [
+        "punctuation.definition.string.begin.tex",
+        "punctuation.definition.string.end.tex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Math \\\\",
+      "scope": "punctuation.definition.constant.math.tex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {}",
+      "scope": [
+        "punctuation.section.group.tex",
+        "punctuation.definition.arguments.begin.latex",
+        "punctuation.definition.arguments.end.latex",
+        "punctuation.definition.arguments.latex"
+      ],
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: {text}",
+      "scope": "meta.group.braces.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: Other Math",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: {var}",
+      "scope": "variable.parameter.function.latex",
+      "settings": {
+        "foreground": "#F0AA0B"
+      }
+    },
+    {
+      "name": "Tex: Other Math String",
+      "scope": "string.other.math.tex",
+      "settings": {
+        "foreground": "#b58900"
+      }
+    },
+    {
+      "name": "Tex: \\label",
+      "scope": [
+        "keyword.control.label.latex",
+        "text.tex.latex constant.other.general.math.tex"
+      ],
+      "settings": {
+        "foreground": "#1fd2df"
+      }
+    },
+    {
+      "name": "Tex: \\label { }",
+      "scope": "variable.parameter.definition.label.latex",
+      "settings": {
+        "foreground": "#dc322f"
+      }
+    },
+    {
+      "name": "Tex: Function",
+      "scope": "support.function.be.latex",
+      "settings": {
+        "foreground": "#859900"
+      }
+    },
+    {
+      "name": "Tex: Support Function Section",
+      "scope": "support.function.section.latex",
+      "settings": {
+        "foreground": "#cb4b16"
+      }
+    },
+    {
+      "name": "Tex: Reference Label",
+      "scope": "keyword.control.ref.latex",
+      "settings": {
+        "foreground": "#2aa198"
+      }
+    },
+    {
+      "name": "Tex: Curly Brackets",
+      "scope": [
+        "punctuation.math.begin.bracket.curly",
+        "punctuation.math.end.bracket.curly"
+      ],
+      "settings": {
+        "foreground": "#8E8E90"
+      }
+    },
+    {
+      "name": "Tex: New Line Label \\",
+      "scope": [
+        "keyword.control.equation.newline.latex",
+        "keyword.control.newline.tex"
+      ],
+      "settings": {
+        "foreground": "#c0b12d"
       }
     }
   ]


### PR DESCRIPTION
I add support for latex syntax highlight. You can use LATEX.tex to see the difference. This modification only applies to latex file. That is, syntax highlighting of other languages stay the same.