### PR TITLE
Update Eva-Dark.json

### DIFF
--- a/VSCode/themes/Eva-Dark.json
+++ b/VSCode/themes/Eva-Dark.json
@@ -337,7 +337,7 @@
 		"symbolIcon.unitForeground": "#FF9070",
 		"symbolIcon.variableForeground": "#B0B7C3",//颜色同变量
         "tab.activeBackground": "#282c34",
-        "tab.activeBorder": "#282c3400",
+        "tab.activeBorder": "#FF9070",
         "tab.activeBorderTop": "#282c3400",
         "tab.activeForeground": "#d7dae0",
         "tab.activeModifiedBorder": "#A78CFA",


### PR DESCRIPTION
Add border color to `tab.activeBorder` to make it visually contrast more from other inactive tabs.

![image](https://user-images.githubusercontent.com/20289967/150078134-76464bd0-1348-45d2-b0c2-af92c80251b1.png)
