### PR TITLE
Fix text colors for React/JSX

### DIFF
--- a/VSCode/themes/Eva-Dark-Bold.json
+++ b/VSCode/themes/Eva-Dark-Bold.json
@@ -860,7 +860,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#8792AA"
+            "foreground": "#B0B7C3"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",

--- a/VSCode/themes/Eva-Dark-Italic.json
+++ b/VSCode/themes/Eva-Dark-Italic.json
@@ -666,7 +666,7 @@
             "fontStyle": "",
             "foreground": "#6495EE"
         }
-    }, 
+    },
     {
         "name": "Classes",
         "scope": "entity.name.type, entity.name.type.class, entity.name.scope-resolution, entity.name.type.struct, entity.other.inherited-class, entity.name.type.interface, entity.other.inherited-classentity.name.type.interface,keyword.interface, entity.name.type.delegate, support.class, storage.type.cs, support.class.builtin, support.type.graphql",
@@ -800,7 +800,7 @@
             "fontStyle": "",
             "foreground": "#FF9070"
         }
-    }, 
+    },
     {
         "name": "constant,值为数字的常量;enum枚举里的元素,Infinity",
         "scope": "support.constant.dom,support.constant.property.math,support.constant.ext,support.constant.core, entity.name.function.preprocessor.c, constant.other.js, meta.at-rule.keyframes.scss entity.other.attribute-name.scss, constant,variable.other.enummember, constant.other.enum, entity.name.variable.enum-member,constant.language.infinity",
@@ -869,7 +869,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#8792AA"
+            "foreground": "#B0B7C3"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",
@@ -1074,7 +1074,7 @@
             "fontStyle": "italic",
             "foreground": "#F02B77"
         }
-    }, 
+    },
     {
         "scope": "keyword.other.debugger",
         "settings": {

--- a/VSCode/themes/Eva-Dark.json
+++ b/VSCode/themes/Eva-Dark.json
@@ -860,7 +860,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#8792AA"
+            "foreground": "#B0B7C3"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",

--- a/VSCode/themes/Eva-Light-Bold.json
+++ b/VSCode/themes/Eva-Light-Bold.json
@@ -861,7 +861,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#A0A1A7"
+            "foreground": "#626264"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",

--- a/VSCode/themes/Eva-Light-Italic.json
+++ b/VSCode/themes/Eva-Light-Italic.json
@@ -867,7 +867,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#A0A1A7"
+            "foreground": "#626264"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",

--- a/VSCode/themes/Eva-Light.json
+++ b/VSCode/themes/Eva-Light.json
@@ -860,7 +860,7 @@
         "scope": "meta.jsx.children",
         "settings": {
             "fontStyle": "",
-            "foreground": "#A0A1A7"
+            "foreground": "#626264"
         }
     }, {
         "name": "block,embedded,definition,bracket,typeparameters;大括号 {}, 中括号[], 圆括号(), 尖括号<>",


### PR DESCRIPTION
Currently, `meta.jsx.children` is using a color that makes it look like a comment. This PR fixes text colors for React (jsx) by matching the same colors that are being used for HTML.

### Light Before

![image](https://user-images.githubusercontent.com/2811287/187290713-c20e1577-fb15-4e64-a6b7-05c9fda4ac13.png)

### Light After

![image](https://user-images.githubusercontent.com/2811287/187290564-f9287181-0c57-417f-9236-928b945941f7.png)

### Dark Before

![image](https://user-images.githubusercontent.com/2811287/187290389-22af66f9-7242-4738-bf76-2475cb85ce4c.png)

### Dark After

![image](https://user-images.githubusercontent.com/2811287/187290257-6b771c3b-acc2-4d72-af45-a47edb087e47.png)
