### PR TITLE
[feat] Add support for diff/patch files, close #98

### DIFF
--- a/themes/Eva-Dark-Bold.json
+++ b/themes/Eva-Dark-Bold.json
@@ -885,5 +885,27 @@
                 "foreground": "#E51400"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#D87878"
+            }
+        },
     ]
 }

--- a/themes/Eva-Dark-Italic.json
+++ b/themes/Eva-Dark-Italic.json
@@ -885,5 +885,27 @@
                 "foreground": "#E51400"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#D87878"
+            }
+        },
     ]
 }

--- a/themes/Eva-Dark.json
+++ b/themes/Eva-Dark.json
@@ -885,5 +885,26 @@
                 "foreground": "#E51400"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#D87878"
+            }
+        },
     ]
 }

--- a/themes/Eva-Light-Bold.json
+++ b/themes/Eva-Light-Bold.json
@@ -885,5 +885,27 @@
                 "foreground": "#EC0000"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "fontStyle": "bold",
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#C01818"
+            }
+        },
     ]
 }

--- a/themes/Eva-Light-Italic.json
+++ b/themes/Eva-Light-Italic.json
@@ -885,5 +885,27 @@
                 "foreground": "#EC0000"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "fontStyle": "italic",
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#C01818"
+            }
+        },
     ]
 }

--- a/themes/Eva-Light.json
+++ b/themes/Eva-Light.json
@@ -885,5 +885,26 @@
                 "foreground": "#EC0000"
             }
         },
+        {
+            "name": "diff",
+            "scope": "meta.diff.range.unified,meta.diff.header.from-file,meta.diff.header.to-file,punctuation.definition.from-file.diff,punctuation.definition.to-file.diff",
+            "settings": {
+                "foreground": "#A860D8"
+            }
+        },
+        {
+            "name": "inserted.diff",
+            "scope": "markup.inserted.diff",
+            "settings": {
+                "foreground": "#30C060"
+            }
+        },
+        {
+            "name": "deleted.diff",
+            "scope": "markup.deleted.diff",
+            "settings": {
+                "foreground": "#C01818"
+            }
+        },
     ]
 }


### PR DESCRIPTION
Both diff files and patch files are parsed with the same language mode.
Two colors are used to draw `markup.deleted.diff` for easy identification