### PR TITLE
Fixed typo: 'Pyhton' --> 'Python'

### DIFF
--- a/documents/languages.md
+++ b/documents/languages.md
@@ -8,7 +8,7 @@ Tested with the following languages in native environment, except derived framew
 - PHP
 - Rust
 - Ruby
-- Pyhton
+- Python
 - Golang
 - Haskell
 - Dart


### PR DESCRIPTION
This commit addresses a typographical error where the term "Pyhton" was incorrectly used instead of "Python"